### PR TITLE
Change fab color to dark blue

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,6 +27,6 @@
 
     <color name="color_primary">@color/theme_blue</color>
     <color name="color_primary_dark">@color/theme_blue_dark</color>
-    <color name="color_accent">@color/theme_silver</color>
+    <color name="color_accent">@color/theme_blue_dark</color>
 </resources>
 


### PR DESCRIPTION
The silver fab doesn't really look good at the bright theme

Before
![screenshot_2017-05-27-21-53-08](https://cloud.githubusercontent.com/assets/22525368/26524096/a38d6e2a-4328-11e7-971e-1129cc258de4.png)
![screenshot_2017-05-27-21-55-19](https://cloud.githubusercontent.com/assets/22525368/26524097/a391cdc6-4328-11e7-8071-225615369992.png)
After
![screenshot_2017-05-27-21-56-59](https://cloud.githubusercontent.com/assets/22525368/26524098/a39748dc-4328-11e7-9433-7a005fe9cf35.png)
![screenshot_2017-05-27-21-57-06](https://cloud.githubusercontent.com/assets/22525368/26524099/a39ed3c2-4328-11e7-8c0c-8ba90b5d35df.png)



Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>