### PR TITLE
Update es config.xml

### DIFF
--- a/app/src/main/res/values-es/config.xml
+++ b/app/src/main/res/values-es/config.xml
@@ -17,7 +17,7 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">Ninguna</string>
-    <string name="default_decimal_separator">.</string>
+    <string name="default_group_separator">Ninguno</string>
+    <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>


### PR DESCRIPTION
With "Ninguna" instead of "Ninguno" (please check strings.xml) "N" was default group separator.
"," is the most used decimal separator in spanish speaking countries (Argentina, Bolivia, Chile, Colombia, Ecuador, España, Paraguay, Peru, Uruguay, Venezuela) whereas "." is used in Bolivia, Mexico and Central America countries.