### PR TITLE
Use HTTPS in currency API

### DIFF
--- a/app/src/main/java/com/physphil/android/unitconverterultimate/api/CurrencyApi.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/api/CurrencyApi.java
@@ -25,7 +25,7 @@ import retrofit2.converter.simplexml.SimpleXmlConverterFactory;
  */
 public class CurrencyApi {
 
-    private static final String BASE_URL = "http://www.ecb.europa.eu/stats/eurofxref/";
+    private static final String BASE_URL = "https://www.ecb.europa.eu/stats/eurofxref/";
     private static CurrencyApi mInstance;
 
     private CurrencyService mService;


### PR DESCRIPTION
Using HTTPS is always a good thing. The ECB website seems to be available using HTTPS, although I was just too lazy to build and test the app. ;)