### PR TITLE
Add Icelandic Krona ISK to Currency Conversions

### DIFF
--- a/app/src/main/java/com/physphil/android/unitconverterultimate/api/models/Currencies.kt
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/api/models/Currencies.kt
@@ -49,6 +49,7 @@ enum class Country {
     IDR,
     ILS,
     INR,
+    ISK,
     JPY,
     KRW,
     MXN,

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.java
@@ -50,6 +50,7 @@ public class Unit {
     public static final int IDR = 1312;
     public static final int ILS = 1313;
     public static final int INR = 1314;
+    public static final int ISK = 1332;
     public static final int JPY = 1315;
     public static final int KRW = 1316;
     public static final int MXN = 1317;
@@ -190,7 +191,7 @@ public class Unit {
     public static final int CUBIC_YARD = 1219;
 
     @IntDef({SQ_KILOMETRES, SQ_METRES, SQ_CENTIMETRES, HECTARE, SQ_MILE, SQ_YARD, SQ_FOOT, SQ_INCH, ACRE,
-            AUD, BGN, BRL, CDN, CHF, CNY, CZK, DKK, EUR, GBP, HKD, HRK, HUF, IDR, ILS, INR, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, RUB, SEK, SGD, THB, LIRA, USD, ZAR,
+            AUD, BGN, BRL, CDN, CHF, CNY, CZK, DKK, EUR, GBP, HKD, HRK, HUF, IDR, ILS, INR, ISK, JPY, KRW, MXN, MYR, NOK, NZD, PHP, PLN, RON, RUB, SEK, SGD, THB, LIRA, USD, ZAR,
             BIT, BYTE, KILOBIT, KILOBYTE, MEGABIT, MEGABYTE, GIGABIT, GIGABYTE, TERABIT, TERABYTE,
             JOULE, KILOJOULE, CALORIE, KILOCALORIE, BTU, FT_LBF, IN_LBF, KILOWATT_HOUR, ELECTRON_VOLT,
             MPG_US, MPG_UK, L_100K, KM_L, MILES_L,

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
@@ -148,6 +148,7 @@ public final class Conversions {
             units.add(new Unit(EUR, R.string.eur, 1.0, 1.0));
             units.add(new Unit(HKD, R.string.hkd, 1 / map.get(Country.HKD), map.get(Country.HKD)));
             units.add(new Unit(HUF, R.string.huf, 1 / map.get(Country.HUF), map.get(Country.HUF)));
+            units.add(new Unit(ISK, R.string.isk, 1 / map.get(Country.ISK), map.get(Country.ISK)));
             units.add(new Unit(INR, R.string.inr, 1 / map.get(Country.INR), map.get(Country.INR)));
             units.add(new Unit(IDR, R.string.idr, 1 / map.get(Country.IDR), map.get(Country.IDR)));
             units.add(new Unit(ILS, R.string.ils, 1 / map.get(Country.ILS), map.get(Country.ILS)));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="idr">Indonesian Rupiah</string>
     <string name="ils">Israeli Shekel</string>
     <string name="inr">Indian Rupee</string>
+    <string name="isk">Icelandic Krona</string>
     <string name="jpy">Japanese Yen</string>
     <string name="krw">Korean Won</string>
     <string name="mxn">Mexican Peso</string>


### PR DESCRIPTION
Add the Icelandic Krona to the ***Currency*** conversion list.  Icelandic Krona, ISK, is included in the API (https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml), but was not included in the Unit Converter Ultimate.  See the screenshots below for illustration.

![isk](https://user-images.githubusercontent.com/3827611/56336215-53a54d00-6154-11e9-9702-aa73e0882851.png)