### PR TITLE
Update Malaysian Ringgit MYR conversionFromBase Parameter

### DIFF
--- a/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
@@ -153,7 +153,7 @@ public final class Conversions {
             units.add(new Unit(ILS, R.string.ils, 1 / map.get(Country.ILS), map.get(Country.ILS)));
             units.add(new Unit(JPY, R.string.jpy, 1 / map.get(Country.JPY), map.get(Country.JPY)));
             units.add(new Unit(KRW, R.string.krw, 1 / map.get(Country.KRW), map.get(Country.KRW)));
-            units.add(new Unit(MYR, R.string.myr, 1 / map.get(Country.MYR), MYR));
+            units.add(new Unit(MYR, R.string.myr, 1 / map.get(Country.MYR), map.get(Country.MYR)));
             units.add(new Unit(MXN, R.string.mxn, 1 / map.get(Country.MXN), map.get(Country.MXN)));
             units.add(new Unit(NZD, R.string.nzd, 1 / map.get(Country.NZD), map.get(Country.NZD)));
             units.add(new Unit(NOK, R.string.nok, 1 / map.get(Country.NOK), map.get(Country.NOK)));


### PR DESCRIPTION
Any currency conversion to Malaysian Ringgit was incorrect since the `conversionFromBase` parameter was set to `MYR` rather than `map.get(Country.MYR)`.  The bug can be easily seen when converting 1.0 Euro to Malaysian Ringgit.  The conversion should be [4.6724 according to the API](https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml), but it was 1318 instead, which is the [value of the `MYR` constant](https://github.com/physphil/UnitConverterUltimate/blob/6aa03284c21ed2ce825f3e6ca3c00f523cfceeaa/app/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.java#L56).  See the screenshots below for illustration.

![myr](https://user-images.githubusercontent.com/3827611/56336853-e0e9a100-6156-11e9-863e-fd957747fcf4.png)