### PR TITLE
GH-201: Save group separator by index

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".PreferencesActivity"
+            android:name=".settings.PreferencesActivity"
             android:label="@string/title_activity_settings"/>
         <activity
             android:name=".AcknowledgementsActivity"

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/BaseActivity.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/BaseActivity.java
@@ -17,9 +17,12 @@
 package com.physphil.android.unitconverterultimate;
 
 import android.os.Bundle;
+import android.view.MenuItem;
+
+import com.physphil.android.unitconverterultimate.settings.Preferences;
+
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
-import android.view.MenuItem;
 
 /**
  * Base Activity class for application

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/MainActivity.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/MainActivity.java
@@ -30,6 +30,8 @@ import android.view.inputmethod.InputMethodManager;
 import com.physphil.android.unitconverterultimate.fragments.ConversionFragment;
 import com.physphil.android.unitconverterultimate.fragments.HelpDialogFragment;
 import com.physphil.android.unitconverterultimate.models.Conversion;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
+import com.physphil.android.unitconverterultimate.settings.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.presenters.MainActivityPresenter;
 import com.physphil.android.unitconverterultimate.presenters.MainActivityView;
 import com.physphil.android.unitconverterultimate.util.Conversions;

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/MainActivity.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/MainActivity.java
@@ -20,22 +20,23 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import com.google.android.material.navigation.NavigationView;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
+import com.google.android.material.navigation.NavigationView;
 import com.physphil.android.unitconverterultimate.fragments.ConversionFragment;
 import com.physphil.android.unitconverterultimate.fragments.HelpDialogFragment;
 import com.physphil.android.unitconverterultimate.models.Conversion;
-import com.physphil.android.unitconverterultimate.settings.Preferences;
-import com.physphil.android.unitconverterultimate.settings.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.presenters.MainActivityPresenter;
 import com.physphil.android.unitconverterultimate.presenters.MainActivityView;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
+import com.physphil.android.unitconverterultimate.settings.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.util.Conversions;
 import com.physphil.android.unitconverterultimate.util.IntentFactory;
+
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
 
 
 /**

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/ConversionFragment.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/ConversionFragment.java
@@ -20,11 +20,6 @@ import android.content.ClipData;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.fragment.app.Fragment;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -41,15 +36,17 @@ import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.ViewFlipper;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
 import com.physphil.android.unitconverterultimate.BuildConfig;
-import com.physphil.android.unitconverterultimate.Preferences;
-import com.physphil.android.unitconverterultimate.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.R;
 import com.physphil.android.unitconverterultimate.UnitConverterApplication;
 import com.physphil.android.unitconverterultimate.data.DataAccess;
 import com.physphil.android.unitconverterultimate.models.Conversion;
 import com.physphil.android.unitconverterultimate.models.ConversionState;
 import com.physphil.android.unitconverterultimate.models.Unit;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
+import com.physphil.android.unitconverterultimate.settings.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.presenters.ConversionPresenter;
 import com.physphil.android.unitconverterultimate.presenters.ConversionView;
 import com.physphil.android.unitconverterultimate.util.Conversions;
@@ -57,6 +54,10 @@ import com.physphil.android.unitconverterultimate.util.IntentFactory;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+
+import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.fragment.app.Fragment;
 
 /**
  * Base fragment to display units to convert

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/ConversionFragment.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/ConversionFragment.java
@@ -374,11 +374,11 @@ public final class ConversionFragment extends Fragment implements ConversionView
         DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
         symbols.setDecimalSeparator(mPrefs.getDecimalSeparator().charAt(0));
 
-        String groupSeparator = mPrefs.getGroupSeparator();
-        boolean isSeparatorUsed = !groupSeparator.equals(mAppContext.getString(R.string.group_separator_none));
+        Character groupSeparator = mPrefs.getGroupSeparator();
+        boolean isSeparatorUsed = groupSeparator != null;
         formatter.setGroupingUsed(isSeparatorUsed);
         if (isSeparatorUsed) {
-            symbols.setGroupingSeparator(groupSeparator.charAt(0));
+            symbols.setGroupingSeparator(groupSeparator);
         }
 
         formatter.setDecimalFormatSymbols(symbols);
@@ -488,7 +488,7 @@ public final class ConversionFragment extends Fragment implements ConversionView
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if (key.equals(Preferences.PREFS_NUMBER_OF_DECIMALS) ||
                 key.equals(Preferences.PREFS_DECIMAL_SEPARATOR) ||
-                key.equals(Preferences.PREFS_GROUP_SEPARATOR)) {
+                key.equals(Preferences.PREFS_GROUP_SEPARATOR_V2)) {
             mTxtResult.setText(getDecimalFormat().format(mResult));
         }
     }

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/ConversionFragment.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/ConversionFragment.java
@@ -45,10 +45,10 @@ import com.physphil.android.unitconverterultimate.data.DataAccess;
 import com.physphil.android.unitconverterultimate.models.Conversion;
 import com.physphil.android.unitconverterultimate.models.ConversionState;
 import com.physphil.android.unitconverterultimate.models.Unit;
-import com.physphil.android.unitconverterultimate.settings.Preferences;
-import com.physphil.android.unitconverterultimate.settings.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.presenters.ConversionPresenter;
 import com.physphil.android.unitconverterultimate.presenters.ConversionView;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
+import com.physphil.android.unitconverterultimate.settings.PreferencesActivity;
 import com.physphil.android.unitconverterultimate.util.Conversions;
 import com.physphil.android.unitconverterultimate.util.IntentFactory;
 

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/HelpDialogFragment.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/fragments/HelpDialogFragment.java
@@ -20,14 +20,15 @@ import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.DialogFragment;
-import androidx.appcompat.app.AlertDialog;
 import android.widget.Toast;
 
-import com.physphil.android.unitconverterultimate.Preferences;
 import com.physphil.android.unitconverterultimate.R;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
 import com.physphil.android.unitconverterultimate.util.IntentFactory;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
 
 /**
  * Dialog fragment to display help text to user

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/models/GroupSeparator.kt
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/models/GroupSeparator.kt
@@ -1,0 +1,8 @@
+package com.physphil.android.unitconverterultimate.models
+
+enum class GroupSeparator(val index: String) {
+    None("0"),
+    Comma("1"),
+    Space("2"),
+    Period("3")
+}

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/models/Language.kt
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/models/Language.kt
@@ -39,22 +39,25 @@ private const val LANG_TURKISH = "tr"
  * Represents a Language that a user can select to display the app in.
  * Copyright (c) 2017 Phil Shadlyn
  */
-enum class Language(val id: String) {
+enum class Language(
+    val id: String,
+    val defaultGroupSeparator: GroupSeparator = GroupSeparator.None
+) {
     DEFAULT(LANG_DEFAULT),
     CROATIAN(LANG_CROATIAN),
-    DUTCH(LANG_DUTCH),
+    DUTCH(LANG_DUTCH, GroupSeparator.Period),
     ENGLISH(LANG_ENGLISH),
     FARSI(LANG_FARSI),
     FRENCH(LANG_FRENCH),
-    GERMAN(LANG_GERMAN),
-    HUNGARIAN(LANG_HUNGARIAN),
-    ITALIAN(LANG_ITALIAN),
-    JAPANESE(LANG_JAPANESE),
+    GERMAN(LANG_GERMAN, GroupSeparator.Period),
+    HUNGARIAN(LANG_HUNGARIAN, GroupSeparator.Period),
+    ITALIAN(LANG_ITALIAN, GroupSeparator.Period),
+    JAPANESE(LANG_JAPANESE, GroupSeparator.Comma),
     NORWEGIAN(LANG_NORWEGIAN),
     PORTUGUESE_BR(LANG_PORTUGUESE_BR),
-    RUSSIAN(LANG_RUSSIAN),
+    RUSSIAN(LANG_RUSSIAN, GroupSeparator.Period),
     SPANISH(LANG_SPANISH),
-    TURKISH(LANG_TURKISH);
+    TURKISH(LANG_TURKISH, GroupSeparator.Period);
 
     val displayStringId = when (id) {
         LANG_CROATIAN -> R.string.language_croatian

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/presenters/ConversionPresenter.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/presenters/ConversionPresenter.java
@@ -16,7 +16,7 @@
 
 package com.physphil.android.unitconverterultimate.presenters;
 
-import com.physphil.android.unitconverterultimate.Preferences;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
 import com.physphil.android.unitconverterultimate.R;
 import com.physphil.android.unitconverterultimate.api.CurrencyApi;
 import com.physphil.android.unitconverterultimate.api.models.Currencies;

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/presenters/MainActivityPresenter.kt
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/presenters/MainActivityPresenter.kt
@@ -18,7 +18,7 @@ package com.physphil.android.unitconverterultimate.presenters
 
 import android.content.Context
 import android.os.Build
-import com.physphil.android.unitconverterultimate.Preferences
+import com.physphil.android.unitconverterultimate.settings.Preferences
 import com.physphil.android.unitconverterultimate.models.Language
 import java.util.*
 

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/settings/Preferences.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/settings/Preferences.java
@@ -27,6 +27,7 @@ import com.physphil.android.unitconverterultimate.models.Conversion;
 import com.physphil.android.unitconverterultimate.models.Language;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Preferences class
@@ -38,13 +39,16 @@ public class Preferences {
     public static final String PREFS_FROM_VALUE = "from_value";
     public static final String PREFS_NUMBER_OF_DECIMALS = "number_decimals";
     public static final String PREFS_DECIMAL_SEPARATOR = "decimal_separator";
-    public static final String PREFS_GROUP_SEPARATOR = "group_separator";
+    private static final String PREFS_GROUP_SEPARATOR = "group_separator";
+    public static final String PREFS_GROUP_SEPARATOR_V2 = "group_separator_v2";
     public static final String PREFS_HAS_RATED = "has_rated";
     public static final String PREFS_APP_OPEN_COUNT = "app_open_count";
     public static final String PREFS_SHOW_HELP = "show_help";
     private static final String PREFS_CONVERSION = "conversion";
     private static final String PREFS_CURRENCY_V2 = "currency_v2";
     public static final String PREFS_LANGUAGE = "language";
+
+    private static final String GROUP_SEPARATOR_V2_DEFAULT = "0";
 
     private static Preferences mInstance;
     private SharedPreferences mPrefs;
@@ -103,8 +107,57 @@ public class Preferences {
         return mPrefs.getString(PREFS_DECIMAL_SEPARATOR, mContext.getString(R.string.default_decimal_separator));
     }
 
-    public String getGroupSeparator() {
-        return mPrefs.getString(PREFS_GROUP_SEPARATOR, mContext.getString(R.string.default_group_separator));
+    /**
+     * Returns the group separator being used, or `null` if no separator is used.
+     */
+    @Nullable
+    public Character getGroupSeparator() {
+        // If the v2 preference is missing than populate from v1.
+        if (mPrefs.contains(PREFS_GROUP_SEPARATOR_V2)) {
+            return getSeparatorFromIndex(mPrefs.getString(PREFS_GROUP_SEPARATOR_V2, GROUP_SEPARATOR_V2_DEFAULT));
+        } else {
+            String convertedV1Separator = getSavedV1GroupSeparatorIndexOrNull();
+            String v2Separator = convertedV1Separator != null ? convertedV1Separator : GROUP_SEPARATOR_V2_DEFAULT;
+            mPrefs.edit().putString(PREFS_GROUP_SEPARATOR_V2, v2Separator).apply();
+            return getSeparatorFromIndex(v2Separator);
+        }
+    }
+
+    /**
+     * Map a saved index in shared preferences to a group separator character.
+     */
+    private Character getSeparatorFromIndex(String index) {
+        switch (index) {
+            case "1":
+                return ',';
+            case "2":
+                return ' ';
+            case "3":
+                return '.';
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Map the v1 group separator to its appropriate index in v2, or `null` if there is no saved
+     * v1 group separator.
+     */
+    @Nullable
+    private String getSavedV1GroupSeparatorIndexOrNull() {
+        if (mPrefs.contains(PREFS_GROUP_SEPARATOR)) {
+            switch (mPrefs.getString(PREFS_GROUP_SEPARATOR, "should never happen")) {
+                case ",":
+                    return "1";
+                case " ":
+                    return "2";
+                case ".":
+                    return "3";
+                default:
+                    return null;
+            }
+        }
+        return null;
     }
 
     public void setShowHelp(boolean showHelp) {

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/settings/Preferences.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/settings/Preferences.java
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-package com.physphil.android.unitconverterultimate;
+package com.physphil.android.unitconverterultimate.settings;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
+import com.physphil.android.unitconverterultimate.R;
 import com.physphil.android.unitconverterultimate.api.models.Currencies;
 import com.physphil.android.unitconverterultimate.models.Conversion;
 import com.physphil.android.unitconverterultimate.models.Language;
+
+import androidx.annotation.NonNull;
 
 /**
  * Preferences class

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/settings/Preferences.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/settings/Preferences.java
@@ -19,6 +19,7 @@ package com.physphil.android.unitconverterultimate.settings;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 import com.google.gson.Gson;
 import com.physphil.android.unitconverterultimate.R;
@@ -47,8 +48,6 @@ public class Preferences {
     private static final String PREFS_CONVERSION = "conversion";
     private static final String PREFS_CURRENCY_V2 = "currency_v2";
     public static final String PREFS_LANGUAGE = "language";
-
-    private static final String GROUP_SEPARATOR_V2_DEFAULT = "0";
 
     private static Preferences mInstance;
     private SharedPreferences mPrefs;
@@ -112,12 +111,14 @@ public class Preferences {
      */
     @Nullable
     public Character getGroupSeparator() {
-        // If the v2 preference is missing than populate from v1.
+        String defaultSeparator = getLanguage().getDefaultGroupSeparator().getIndex();
+        Log.d("phil", "Default separator = " + defaultSeparator);
         if (mPrefs.contains(PREFS_GROUP_SEPARATOR_V2)) {
-            return getSeparatorFromIndex(mPrefs.getString(PREFS_GROUP_SEPARATOR_V2, GROUP_SEPARATOR_V2_DEFAULT));
+            return getSeparatorFromIndex(mPrefs.getString(PREFS_GROUP_SEPARATOR_V2, defaultSeparator));
         } else {
+            // If the v2 preference is missing than populate from v1.
             String convertedV1Separator = getSavedV1GroupSeparatorIndexOrNull();
-            String v2Separator = convertedV1Separator != null ? convertedV1Separator : GROUP_SEPARATOR_V2_DEFAULT;
+            String v2Separator = convertedV1Separator != null ? convertedV1Separator : defaultSeparator;
             mPrefs.edit().putString(PREFS_GROUP_SEPARATOR_V2, v2Separator).apply();
             return getSeparatorFromIndex(v2Separator);
         }
@@ -125,6 +126,11 @@ public class Preferences {
 
     /**
      * Map a saved index in shared preferences to a group separator character.
+     *
+     * "0" - None
+     * "1" - ,
+     * "2" - ' '
+     * "3" - .
      */
     private Character getSeparatorFromIndex(String index) {
         switch (index) {

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/settings/PreferencesActivity.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/settings/PreferencesActivity.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package com.physphil.android.unitconverterultimate;
+package com.physphil.android.unitconverterultimate.settings;
 
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 
-import com.physphil.android.unitconverterultimate.fragments.PreferencesFragment;
+import com.physphil.android.unitconverterultimate.BaseActivity;
+import com.physphil.android.unitconverterultimate.R;
 
 /**
  * Activity to host preferences fragment

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/settings/PreferencesFragment.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/settings/PreferencesFragment.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.physphil.android.unitconverterultimate.fragments;
+package com.physphil.android.unitconverterultimate.settings;
 
 import android.content.ActivityNotFoundException;
 import android.content.SharedPreferences;
@@ -27,7 +27,6 @@ import android.widget.Toast;
 
 import com.physphil.android.unitconverterultimate.AcknowledgementsActivity;
 import com.physphil.android.unitconverterultimate.BuildConfig;
-import com.physphil.android.unitconverterultimate.Preferences;
 import com.physphil.android.unitconverterultimate.R;
 import com.physphil.android.unitconverterultimate.UnitConverterApplication;
 import com.physphil.android.unitconverterultimate.models.Language;

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
@@ -18,7 +18,7 @@ package com.physphil.android.unitconverterultimate.util;
 
 import android.content.Context;
 
-import com.physphil.android.unitconverterultimate.Preferences;
+import com.physphil.android.unitconverterultimate.settings.Preferences;
 import com.physphil.android.unitconverterultimate.R;
 import com.physphil.android.unitconverterultimate.api.models.Country;
 import com.physphil.android.unitconverterultimate.api.models.Currencies;

--- a/app/src/main/res/values-de/config.xml
+++ b/app/src/main/res/values-de/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">.</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-es/config.xml
+++ b/app/src/main/res/values-es/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">Ninguno</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-fa/config.xml
+++ b/app/src/main/res/values-fa/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">هیچ</string>
     <string name="default_decimal_separator">.</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-fr/config.xml
+++ b/app/src/main/res/values-fr/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">Aucun</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-hr/config.xml
+++ b/app/src/main/res/values-hr/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">Nijedno</string>
     <string name="default_decimal_separator">.</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-hu/config.xml
+++ b/app/src/main/res/values-hu/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">.</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-it/config.xml
+++ b/app/src/main/res/values-it/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">.</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-ja/config.xml
+++ b/app/src/main/res/values-ja/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">,</string>
     <string name="default_decimal_separator">.</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-nb/config.xml
+++ b/app/src/main/res/values-nb/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">Ingen</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-nl/config.xml
+++ b/app/src/main/res/values-nl/config.xml
@@ -18,7 +18,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">.</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-pt-rBR/config.xml
+++ b/app/src/main/res/values-pt-rBR/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">Nenhum</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-ru/config.xml
+++ b/app/src/main/res/values-ru/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">.</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values-tr/config.xml
+++ b/app/src/main/res/values-tr/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">.</string>
     <string name="default_decimal_separator">,</string>
     <integer name="num_digits_from">15</integer>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -31,7 +31,14 @@
         <item>10</item>
     </string-array>
 
-    <string-array name="group_separators" translatable="false">
+    <string-array name="group_separator_index" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
+    <string-array name="group_separator_value" translatable="false">
         <item>@string/group_separator_none</item>
         <item>,</item>
         <item>" "</item>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -17,7 +17,6 @@
 
 <resources>
     <string name="default_number_decimals">4</string>
-    <string name="default_group_separator">None</string>
     <string name="default_decimal_separator">.</string>
     <integer name="num_digits_from">15</integer>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -29,12 +29,11 @@
             android:entryValues="@array/number_decimals"/>
 
         <ListPreference
-            android:key="group_separator"
+            android:key="group_separator_v2"
             android:title="@string/prefs_title_group_separator"
             android:summary="@string/prefs_summary_group_separator"
-            android:defaultValue="@string/default_group_separator"
-            android:entries="@array/group_separators"
-            android:entryValues="@array/group_separators"/>
+            android:entries="@array/group_separator_value"
+            android:entryValues="@array/group_separator_index"/>
 
         <ListPreference
             android:key="decimal_separator"


### PR DESCRIPTION
Fixes #201 

Previously I was saving `group_separator` by the actual character separator. This was causing a bug when switching languages due to translations of the `None` separator. Save by an id instead and convert that id to the proper character.