### PR TITLE
Fix crash due to Russian Rouble

### DIFF
--- a/app/src/main/java/com/physphil/android/unitconverterultimate/api/models/Currencies.kt
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/api/models/Currencies.kt
@@ -59,7 +59,6 @@ enum class Country {
     PHP,
     PLN,
     RON,
-    RUB,
     SEK,
     SGD,
     THB,

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
@@ -161,7 +161,6 @@ public final class Conversions {
             units.add(new Unit(PHP, R.string.php, 1 / map.get(Country.PHP), map.get(Country.PHP)));
             units.add(new Unit(PLN, R.string.pln, 1 / map.get(Country.PLN), map.get(Country.PLN)));
             units.add(new Unit(RON, R.string.ron, 1 / map.get(Country.RON), map.get(Country.RON)));
-            units.add(new Unit(RUB, R.string.rub, 1 / map.get(Country.RUB), map.get(Country.RUB)));
             units.add(new Unit(SGD, R.string.sgd, 1 / map.get(Country.SGD), map.get(Country.SGD)));
             units.add(new Unit(ZAR, R.string.zar, 1 / map.get(Country.ZAR), map.get(Country.ZAR)));
             units.add(new Unit(SEK, R.string.sek, 1 / map.get(Country.SEK), map.get(Country.SEK)));

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Philippinischer Peso</string>
     <string name="pln">Polnischer Złoty</string>
     <string name="ron">Rumänischer Leu</string>
-    <string name="rub">Russischer Rubel</string>
     <string name="sek">Schwedische Krone</string>
     <string name="sgd">Singapur-Dollar</string>
     <string name="thb">Thailändischer Baht</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Peso filipino</string>
     <string name="pln">Zloty polaco</string>
     <string name="ron">Leu rumano</string>
-    <string name="rub">Rublo ruso</string>
     <string name="sek">Corona sueca</string>
     <string name="sgd">Dolar de Singapur</string>
     <string name="thb">Baht tailandés</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">پزوی فیلیپین</string>
     <string name="pln">لهستانی زلوتی</string>
     <string name="ron">رومانیایی ل</string>
-    <string name="rub">روبل روسیه</string>
     <string name="sek">کرون سوئد</string>
     <string name="sgd">دلار سنگاپور</string>
     <string name="thb">بات تایلند</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -262,7 +262,6 @@
     <string name="php">Peso Philippin</string>
     <string name="pln">Zloty Polonais</string>
     <string name="ron">Leu Roumain</string>
-    <string name="rub">Rouble Russe</string>
     <string name="sek">Couronne Suédoise</string>
     <string name="sgd">Dollar de Singapour</string>
     <string name="thb">Baht Thaïlandais</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Filipinski pezo</string>
     <string name="pln">Poljski zlot</string>
     <string name="ron">Rumunjski lei</string>
-    <string name="rub">Ruski rubalj</string>
     <string name="sek">Švedska kruna</string>
     <string name="sgd">Singapurski dolar</string>
     <string name="thb">Tajlandski bat</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -264,7 +264,6 @@
     <string name="php">Fülöp-szigeteki peso</string>
     <string name="pln">Lengyel złoty</string>
     <string name="ron">Román lej</string>
-    <string name="rub">Orosz rubel</string>
     <string name="sek">Svéd korona</string>
     <string name="sgd">Szingapúri dollár</string>
     <string name="thb">Thaiföldi bát</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Peso Filippino</string>
     <string name="pln">Zloty Polacco</string>
     <string name="ron">Leu Romeno</string>
-    <string name="rub">Rublo Russo</string>
     <string name="sek">Corona Svedese</string>
     <string name="sgd">Dollaro Singapore</string>
     <string name="thb">Baht Thailandese</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">フィリピン・ペソ</string>
     <string name="pln">ポーランド・ズローティ</string>
     <string name="ron">ルーマニア・レウ</string>
-    <string name="rub">ロシア・ルーブル</string>
     <string name="sek">スウェーデン・クローナ</string>
     <string name="sgd">シンガポール・ドル</string>
     <string name="thb">タイ・バーツ</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -264,7 +264,6 @@
     <string name="php">Filippinske Peso</string>
     <string name="pln">Polske Zloty</string>
     <string name="ron">Rumenske Leu</string>
-    <string name="rub">Russiske Rubler</string>
     <string name="sek">Svenske Kroner</string>
     <string name="sgd">Singaporske Dollar</string>
     <string name="thb">Thailandske Baht</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -278,7 +278,6 @@
     <string name="php">Filipijnse Peso</string>
     <string name="pln">Poolse Zloty</string>
     <string name="ron">Roemeense Leu</string>
-    <string name="rub">Russische Roebel</string>
     <string name="sek">Zweedse Kroon</string>
     <string name="sgd">Singapore Dollar</string>
     <string name="thb">Thaise Baht</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Peso Filipino</string>
     <string name="pln">Zloty Polonês</string>
     <string name="ron">Leu Romeno</string>
-    <string name="rub">Rublo Russo</string>
     <string name="sek">Coroa Sueca</string>
     <string name="sgd">Dólar de Singapura</string>
     <string name="thb">Baht Tailandês</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Филиппинское песо</string>
     <string name="pln">Польский злотый</string>
     <string name="ron">Румынский лей</string>
-    <string name="rub">Российский рубль</string>
     <string name="sek">Шведская крона</string>
     <string name="sgd">Сингапурский доллар</string>
     <string name="thb">Тайский бат</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -261,7 +261,6 @@
     <string name="php">Filipinler Pezosu</string>
     <string name="pln">Polonya Zlotisi</string>
     <string name="ron">Romen Leyi</string>
-    <string name="rub">Rus Rublesi</string>
     <string name="sek">İsveç Kronu</string>
     <string name="sgd">Singapur Doları</string>
     <string name="thb">Tayland Bahtı</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,7 +277,6 @@
     <string name="php">Philippine Peso</string>
     <string name="pln">Polish Zloty</string>
     <string name="ron">Romanian Leu</string>
-    <string name="rub">Russian Rouble</string>
     <string name="sek">Swedish Krona</string>
     <string name="sgd">Singapore Dollar</string>
     <string name="thb">Thai Baht</string>


### PR DESCRIPTION
Currency conversion service no longer provides Russian Rouble, which was causing error with parsing.  Quick fix is to remove currency, long term fix is to ensure app won't crash when API changes.