### PR TITLE
Adding units mm of H2O, inches of H2O (water column) and inches of Hg

### DIFF
--- a/Changes.org
+++ b/Changes.org
@@ -1,0 +1,58 @@
+Changelog file by Proper Brgdbald for unit updates
+
+* 2023-08-07
+
+Inches H2O based from wikipedia (https://en.wikipedia.org/wiki/Inch_of_water)
+mm H2O based on Inches H2O divided by 25.4 
+ or https://en.wikipedia.org/wiki/Centimetre_of_water
+  Therefore conventional value
+inHg based from mmHg but multiplied by 25.4 per wikipedia https://en.wikipedia.org/wiki/Inch
+
+String translations are not perfect, please let me know.
+
+
+Main conversion files changed where units are defined and converted.
+- /app/src/main/java/com/physphil/android/unitconverterultimate/
+  - [X] /util/Conversions.java 
+  - [-] /models/Conversion.java
+    - [ ] apparently no units spec'd
+    - [X] partly completing for reference I checked this
+  - [X] /models/Unit.java
+- /v6000/src/main/java/com/physphil/android/unitconverterultimate/
+  - [-] ConversionFragment.kt
+    - [ ] apparently no units spec'd
+    - [X] partly completing for reference I checked this
+  - [ ] /conversion/ConversionRepository.kt
+    - Did not see need to change
+
+
+I did not change the files underneath /app/src/test or /v6000/src/test.
+
+
+List of files changed that contained "metre" and therefore other units:
+- [X] ‎app/src
+  - [X] /main/java/com/physphil/android/unitconverterultimate/models/Unit.java
+  - [X] ‎/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
+- [X] v6000/src
+  - [X] /main/java/com/physphil/android/unitconverterultimate/models/Unit.kt
+  - [X] /main/java/com/physphil/android/unitconverterultimate/data/DataSource.kt
+  - [X] /main/res/values/strings.xml
+- [X] app/src/main/res
+  - [X] ‎/values/strings.xml
+  - [X] ‎/values-it/strings.xml
+  - [X] ‎/values-es/strings.xml
+  - [X] ‎/values-ru/strings.xml need translation
+    - Attempted with other units as sample
+  - [X] ‎/values-hr/strings.xml 
+  - [X] ‎/values-hu/strings.xml need translation
+    - Attempted with other units as sample
+  - [X] ‎/values-fr/strings.xml
+  - [X] ‎/values-pt-rBR/strings.xml
+  - [X] ‎/values-nl/strings.xml
+  - [X] /values-tr/strings.xml
+  - [X] ‎/values-fa/strings.xml
+    - need help with translation and file formatting (Right Justified)
+    - Attempted with other units as sample
+  - [X] /values-de/strings.xml
+  - [X] /values-ja/strings.xml
+  - [X] ‎/values-nb/strings.xml

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.java
@@ -140,6 +140,9 @@ public class Unit {
     public static final int TECHNICAL_ATMOSPHERE = 709;
     public static final int MMHG = 707;
     public static final int TORR = 708;
+    public static final int MMH2O = 709;
+    public static final int INHG = 710;
+    public static final int INH2O = 711;
 
     public static final int KM_HR = 800;
     public static final int MPH = 801;
@@ -198,7 +201,7 @@ public class Unit {
             KILOMETRE, MILE, METRE, CENTIMETRE, MILLIMETRE, MICROMETRE, NANOMETRE, YARD, FEET, INCH, NAUTICAL_MILE, FURLONG, LIGHT_YEAR,
             KILOGRAM, POUND, GRAM, MILLIGRAM, OUNCE, GRAIN, STONE, METRIC_TON, SHORT_TON, LONG_TON,
             WATT, KILOWATT, MEGAWATT, HP, HP_UK, FT_LBF_S, CALORIE_S, BTU_S, KVA,
-            MEGAPASCAL, KILOPASCAL, PASCAL, BAR, PSI, PSF, ATMOSPHERE, TECHNICAL_ATMOSPHERE, MMHG, TORR,
+	    MEGAPASCAL, KILOPASCAL, PASCAL, BAR, PSI, PSF, ATMOSPHERE, TECHNICAL_ATMOSPHERE, MMHG, TORR, MMH2O, INHG, INH2O,
             KM_HR, MPH, M_S, FPS, KNOT,
             CELSIUS, FAHRENHEIT, KELVIN, RANKINE, DELISLE, NEWTON, REAUMUR, ROMER, GAS_MARK,
             YEAR, MONTH, WEEK, DAY, HOUR, MINUTE, SECOND, MILLISECOND, NANOSECOND,

--- a/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
+++ b/app/src/main/java/com/physphil/android/unitconverterultimate/util/Conversions.java
@@ -304,6 +304,9 @@ public final class Conversions {
         units.add(new Unit(TECHNICAL_ATMOSPHERE, R.string.technical_atmosphere, 98066.5, 0.0000101971621297792824257));
         units.add(new Unit(MMHG, R.string.mmhg, 133.322387415, 0.007500615758456563339513));
         units.add(new Unit(TORR, R.string.torr, 133.3223684210526315789, 0.00750061682704169751));
+	units.add(new Unit(MMH2O, R.string.mmh2o, 9.806650, 0.1019716));
+	units.add(new Unit(INHG, R.string.inhg, 3386.388640341, 0.00029529983));
+	units.add(new Unit(INH2O, R.string.inh2o, 249.0889, 0.0040146309));
         addConversion(Conversion.PRESSURE, new Conversion(Conversion.PRESSURE, R.string.pressure, units));
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">Technische Atm.</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
 	<string name="km_h">Kilometer/Stunde</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">Atm Técnica</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometro/hora</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -180,7 +180,10 @@
     <string name="technical_atmosphere">Technical Atm</string>
     <string name="mmhg">میلی متر جیوه</string>
     <string name="torr">Torr</string>
-
+    <string name="mmh2o">میلی متر H2O</string>
+    <string name="inhg">اینچ Hg</string>
+    <string name="inh2o">اینچ H2O</string>
+    
     <!-- سرعت -->
     <string name="km_h">کیلومتر/ساعت</string>
     <string name="mph">مایل/ساعت</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -181,6 +181,9 @@
     <string name="technical_atmosphere">Atm. technique</string>
     <string name="mmhg">mmHg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mmH2O</string>
+    <string name="inhg">inHg</string>
+    <string name="inh2o">inH2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilomètre/heure</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">Technical Atm</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometar/sat</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -183,6 +183,9 @@
     <string name="technical_atmosphere">Technikai atmoszféra</string>
     <string name="mmhg">mmHg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mmH2O</string>
+    <string name="inhg">Hüvelyk Hg</string>
+    <string name="inh2o">Hüvelyk H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilométer/óra</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">Atmosfera Tecnica</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Km/h</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">工学気圧</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">トル</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">キロメートル/時</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -183,6 +183,9 @@
     <string name="technical_atmosphere">Teknisk Atm</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometer/time</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -197,6 +197,9 @@
     <string name="technical_atmosphere">Technical Atm</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometer/uur</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -179,6 +179,9 @@
     <string name="technical_atmosphere">Atmosfera técnica</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Velocidade -->
     <string name="km_h">Quilômetro/hora</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">Технич. атмосфера</string>
     <string name="mmhg">мм рт. ст.</string>
     <string name="torr">Торр</string>
+    <string name="mmh2o">мм H2O</string>
+    <string name="inhg">Дюйм рт. ст.</string>
+    <string name="inh2o">Дюйм H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Километр/час</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -180,6 +180,9 @@
     <string name="technical_atmosphere">Teknik Atmosfer</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometre/saat</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,9 @@
     <string name="technical_atmosphere">Technical Atm</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometre/hour</string>

--- a/v6000/src/main/java/com/physphil/android/unitconverterultimate/data/DataSource.kt
+++ b/v6000/src/main/java/com/physphil/android/unitconverterultimate/data/DataSource.kt
@@ -145,7 +145,10 @@ object PressureDataSource : DataSource<Pressure>() {
         Pressure.Atmosphere to multipliers("101325", "0.0000098692326671601283"),
         Pressure.TechnicalAtmosphere to multipliers("98066.5", "0.0000101971621297792824257"),
         Pressure.MmHg to multipliers("133.322387415", "0.007500615758456563339513"),
-        Pressure.Torr to multipliers("133.3223684210526315789", "0.00750061682704169751")
+        Pressure.Torr to multipliers("133.3223684210526315789", "0.00750061682704169751"),
+	Pressure.MmH2O to multipliers("9.806650", "0.1019716"),
+	Pressure.InHg to multipliers("3386.388640341", "0.00029529983"),
+	Pressure.InH2O to multipliers("249.0889", "0.0040146309")
     )
 }
 

--- a/v6000/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.kt
+++ b/v6000/src/main/java/com/physphil/android/unitconverterultimate/models/Unit.kt
@@ -144,10 +144,13 @@ sealed class Pressure(override val displayStringResId: Int) : Unit() {
     object TechnicalAtmosphere : Pressure(R.string.technical_atmosphere)
     object MmHg : Pressure(R.string.mmhg)
     object Torr : Pressure(R.string.torr)
+    object MmH2O : Pressure(R.string.mmh2o)
+    object InHg : Pressure(R.string.inhg)
+    object InH2O : Pressure(R.string.inh2o)
 
     companion object {
         val all: List<Pressure> = listOf(
-            Megapascal, Kilopascal, Pascal, Bar, Psi, Psf, Atmosphere, TechnicalAtmosphere, MmHg, Torr
+            Megapascal, Kilopascal, Pascal, Bar, Psi, Psf, Atmosphere, TechnicalAtmosphere, MmHg, Torr, MmH2O, InHg, InH2O
         )
     }
 }

--- a/v6000/src/main/res/values/strings.xml
+++ b/v6000/src/main/res/values/strings.xml
@@ -168,6 +168,9 @@
     <string name="technical_atmosphere">Technical Atm</string>
     <string name="mmhg">mm Hg</string>
     <string name="torr">Torr</string>
+    <string name="mmh2o">mm H2O</string>
+    <string name="inhg">in Hg</string>
+    <string name="inh2o">in H2O</string>
 
     <!-- Speed -->
     <string name="km_h">Kilometre/hour</string>


### PR DESCRIPTION
For work in HVAC and process control, I use inches and mm of water column often, and wanted to round out this application. Inches of mercury is a simple translation, I figured it could be added just in case it's needed.

Inches H2O based from Wikipedia (https://en.wikipedia.org/wiki/Inch_of_water).
mm H2O based on inches H2O divided by 25.4 or https://en.wikipedia.org/wiki/Centimetre_of_water
inHg based from mmHg but multiplied by 25.4 per Wikipedia (https://en.wikipedia.org/wiki/Inch)

I made attempts with values-fa/strings.xml, /values-hu/strings.xml, and /values-ru/strings.xml. These likely need translation correction for the terms.